### PR TITLE
Metrics improved

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pairodoro",
 	"displayName": "Pairodoro",
-	"description": "Pairing Timer",
+	"description": "Paired Programming Timer",
 	"publisher": "FordLabs",
 	"license": "MIT",
 	"version": "1.4.0",
@@ -46,6 +46,11 @@
 			"properties": {
 				"pairodoro.player1": {
 					"type": "object",
+					"description": "User definition for first pair",
+					"default": {
+						"name": "Player 1",
+						"color": "#fff"
+					},
 					"properties": {
 						"name": {
 							"type": "string",
@@ -61,6 +66,11 @@
 				},
 				"pairodoro.player2": {
 					"type": "object",
+					"description": "User definition for second pair",
+					"default": {
+						"name": "Player 2",
+						"color": "#fff"
+					},
 					"properties": {
 						"name": {
 							"type": "string",

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,0 +1,1 @@
+export const statusBarCommandId = "pairodoro.showPairingStatus";

--- a/src/PairConfig.ts
+++ b/src/PairConfig.ts
@@ -4,12 +4,10 @@ export default class PairConfig {
   pairStatus: StatusBarItem;
   currentName: string;
 
-  constructor(commandId: string, alignment: number, propertyName: string) {
+  constructor(alignment: number, propertyName: string) {
     this.pairStatus = window.createStatusBarItem(StatusBarAlignment.Right, alignment);
-    this.pairStatus.command = commandId;
     this.currentName = workspace.getConfiguration("pairodoro").get(`${propertyName}.name`) as string;
     this.pairStatus.text = this.currentName;
-
     this.pairStatus.color = workspace.getConfiguration("pairodoro").get(`${propertyName}.color`) as string;
   }
 

--- a/src/TimerStatus.ts
+++ b/src/TimerStatus.ts
@@ -8,57 +8,45 @@ import {
   ExtensionContext
 } from "vscode";
 import PairConfig from "./PairConfig";
+import { statusBarCommandId } from "./Constants";
 export default class TimerStatus {
   timerStatus: StatusBarItem;
   interval: any;
   time: number;
   pairConfigs: PairConfig[];
-  currentPairIndex: number;
   context: ExtensionContext;
 
   isPaused = false;
+  currentPairIndex = 0;
+  pairingInProgress = true;
 
   constructor(context: ExtensionContext, alignment: number, pairConfigs: PairConfig[]) {
     this.context = context;
-    this.timerStatus = window.createStatusBarItem(StatusBarAlignment.Right, alignment);
     this.pairConfigs = pairConfigs;
-    this.context.workspaceState.update(this.pairConfigs[0].getName(), 0);
-    this.context.workspaceState.update(this.pairConfigs[1].getName(), 0);
-
-    const statusBarCommandId = "pairodoro.showPairingStatus";
+    this.timerStatus = window.createStatusBarItem(StatusBarAlignment.Right, alignment);
+    this.time = workspace.getConfiguration("pairodoro").get("seconds") as number;
+    this.timerStatus.command = statusBarCommandId;
+    this.timerStatus.color = "#fff";
 
     context.subscriptions.push(
       commands.registerCommand(statusBarCommandId, () => {
-        window.showInformationMessage("Pause pairing timer?", "Pause", "Continue", "Reset", "End").then(selection => {
-          if (selection === "Pause") {
-            this.isPaused = true;
-          } else if (selection === "Continue") {
-            this.isPaused = false;
-          } else if (selection === "Reset") {
-            this.time = workspace.getConfiguration("pairodoro").get("seconds") as number;
-          } else if (selection === "End") {
-            window.showInformationMessage(
-              `${this.pairConfigs[0].getName()}: Typed 
-                ${this.context.workspaceState.get(this.pairConfigs[0].getName())}
-                characters.\n
-                ${this.pairConfigs[1].getName()}: Typed 
-                ${this.context.workspaceState.get(this.pairConfigs[1].getName())}
-                characters.`
-            );
-            this.clearTimer();
-            this.time = 0;
-          }
-        });
+        if (this.pairingInProgress) {
+          this.showPairingInProgressPopup();
+        } else {
+          this.showStartNewPairingSessionPopup();
+        }
       })
     );
 
-    this.timerStatus.command = statusBarCommandId;
-    this.timerStatus.text = "Happy Pairing!";
-    this.timerStatus.color = "#fff";
+    this.initializeStatusBar();
+  }
 
-    this.time = workspace.getConfiguration("pairodoro").get("seconds") as number;
-
+  // Called when (re)creating the timer status bar object
+  initializeStatusBar() {
     this.currentPairIndex = 0;
+    this.context.workspaceState.update(this.pairConfigs[0].getName(), 0);
+    this.context.workspaceState.update(this.pairConfigs[1].getName(), 0);
+    this.timerStatus.text = "Happy Pairing!";
 
     this.interval = setInterval(() => {
       if (!this.isPaused) {
@@ -74,6 +62,9 @@ export default class TimerStatus {
   }
 
   updateTimerValue() {
+    // TODO: So when we end & restart a pairing session, player2 gets set
+    // this is because we set time to 0, then the block below is called
+    // it's possible that we could use some global state management here :)
     if (this.time === 0) {
       this.time = workspace.getConfiguration("pairodoro").get("seconds") as number;
       this.displayNextPair();
@@ -91,6 +82,10 @@ export default class TimerStatus {
 
   clearTimer() {
     clearInterval(this.interval);
+  }
+
+  showRestartTimerMessage() {
+    this.timerStatus.text = "Start Pairing Session";
   }
 
   private notifyPairSwap() {
@@ -125,5 +120,47 @@ export default class TimerStatus {
 
   private getNextPair(): PairConfig {
     return this.pairConfigs[(this.currentPairIndex + 1) % this.pairConfigs.length];
+  }
+
+  private showStartNewPairingSessionPopup() {
+    window
+      .showInformationMessage(
+        `Start New Pairing Session for ${this.pairConfigs[0].getName()} & ${this.pairConfigs[1].getName()}?`,
+        "Yes",
+        "Cancel"
+      )
+      .then(selection => {
+        if (selection === "Yes") {
+          this.initializeStatusBar();
+          this.pairingInProgress = true;
+        } else if (selection === "Cancel") {
+          // doing nothing seems to close this just fine
+        }
+      });
+  }
+
+  private showPairingInProgressPopup() {
+    window.showInformationMessage("Pause pairing timer?", "Pause", "Continue", "Reset", "End").then(selection => {
+      if (selection === "Pause") {
+        this.isPaused = true;
+      } else if (selection === "Continue") {
+        this.isPaused = false;
+      } else if (selection === "Reset") {
+        this.time = workspace.getConfiguration("pairodoro").get("seconds") as number;
+      } else if (selection === "End") {
+        window.showInformationMessage(
+          `${this.pairConfigs[0].getName()}: Typed 
+            ${this.context.workspaceState.get(this.pairConfigs[0].getName())}
+            characters.\n
+            ${this.pairConfigs[1].getName()}: Typed 
+            ${this.context.workspaceState.get(this.pairConfigs[1].getName())}
+            characters.`
+        );
+        this.clearTimer();
+        this.showRestartTimerMessage();
+        this.time = 0;
+        this.pairingInProgress = false;
+      }
+    });
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,8 +12,8 @@ export function activate(context: vscode.ExtensionContext) {
   });
   context.subscriptions.push(disposable);
 
-  player1Config = new PairConfig("", 200, "player1");
-  player2Config = new PairConfig("", 200, "player2");
+  player1Config = new PairConfig(200, "player1");
+  player2Config = new PairConfig(200, "player2");
   timeRemainingDisplay = new TimerStatus(context, 199, [player1Config, player2Config]);
 
   timeRemainingDisplay.show();


### PR DESCRIPTION
Few things here:

### package.json improvements
* Update description (hopefully better hits on the marketplace is `paired programming` vs `pairing`)
* Add description for the player objects (had none before, showed as blank space :-1: )
* Adds **actual** defaults. The player1/player2 objects were always undefined -- turns out that the default we had before was just for autocomplete when adding fields to the settings.json. Up until now, all of our users have been `undefined` while pairing if they didn't configure 😢 

### Other stuff
* Some code cleanup, mostly around removing some unused stuff for pair configs
* You can now end and restart a pairing sessions
* There's a bug when you restart a pairing session where it defaults the starting pair to whoever the next pair would be. I left a TODO around the code getting fired here. 

I figure it's better to get this all in to prevent more of this undefined nonsense :). 