### PR TITLE
Change keybinding for mac and windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
 		"keybindings": [
 			{
 				"command": "extension.pairodoro",
-				"key": "shift+ctrl+p",
-				"mac": "shift+cmd+p"
+				"key": "alt+ctrl+p",
+				"mac": "alt+cmd+p"
 			}
 		],
 		"configuration": {


### PR DESCRIPTION
The current Pairodoro keybinding (shift+ctrl/cmd+p) conflicts with the default VS Code keybinding for those keys. Having Pairodoro installed prevents users from using that keybinding to show the command palette. This commit uses a new keybinding that does not overlap with any default VS Code keybindings